### PR TITLE
add headers: compare, cfloat, cinttypes, climits, cstdarg, modify headers: utility, algorithm, new, memory, cstddef

### DIFF
--- a/stage2/include/algorithm
+++ b/stage2/include/algorithm
@@ -6,12 +6,12 @@
 namespace std {
 
 template<typename T>
-const T &min(const T &a, const T &b) {
+constexpr const T &min(const T &a, const T &b) {
 	return (b < a) ? b : a;
 }
 
 template<typename T>
-const T &max(const T &a, const T &b) {
+constexpr const T &max(const T &a, const T &b) {
 	return (a < b) ? b : a;
 }
 

--- a/stage2/include/cfloat
+++ b/stage2/include/cfloat
@@ -1,0 +1,6 @@
+#ifndef _CXXSHIM_CFLOAT
+#define _CXXSHIM_CFLOAT
+
+#include <float.h>
+
+#endif // _CXXSHIM_CFLOAT

--- a/stage2/include/cinttypes
+++ b/stage2/include/cinttypes
@@ -1,0 +1,13 @@
+#ifndef _CXXSHIM_CINTTYPES
+#define _CXXSHIM_CINTTYPES
+
+#include <inttypes.h>
+
+namespace std
+{
+
+using ::imaxdiv_t;
+
+} // namespace std
+
+#endif // _CXXSHIM_CINTTYPES

--- a/stage2/include/climits
+++ b/stage2/include/climits
@@ -1,0 +1,6 @@
+#ifndef _CXXSHIM_CLIMITS
+#define _CXXSHIM_CLIMITS
+
+#include <limits.h>
+
+#endif // _CXXSHIM_CLIMITS

--- a/stage2/include/compare
+++ b/stage2/include/compare
@@ -1,0 +1,300 @@
+#ifndef _CXXSHIM_COMPARE
+#define _CXXSHIM_COMPARE
+
+#ifdef CXXSHIM_INTEGRATE_GCC
+
+#include_next <compare>
+
+#else // CXXSHIM_INTEGRATE_GCC
+
+#include <utility>
+
+namespace std
+{
+
+namespace cmp
+{
+
+using value_type = signed char;
+
+enum class order : value_type
+{
+	less = -1,
+	equivalent = 0,
+	greater = 1
+};
+
+enum class ncmp : value_type { unordered = -127 };
+
+struct unspec { constexpr unspec(unspec*) { } };
+
+} // namespace cmp
+
+class partial_ordering {
+	cmp::value_type value;
+
+	constexpr explicit partial_ordering(cmp::order v) noexcept : value(cmp::value_type(v)) { }
+	constexpr explicit partial_ordering(cmp::ncmp v) noexcept : value(cmp::value_type(v)) { }
+
+	constexpr bool is_ordered() const noexcept {
+		return value != cmp::value_type(cmp::ncmp::unordered);
+	}
+
+	public:
+	static const partial_ordering less;
+	static const partial_ordering equivalent;
+	static const partial_ordering greater;
+	static const partial_ordering unordered;
+
+	friend constexpr bool operator==(partial_ordering v, partial_ordering w) noexcept = default;
+
+	friend constexpr bool operator==(partial_ordering v, cmp::unspec) noexcept {
+		return v.is_ordered() && v.value == 0;
+	}
+
+	friend constexpr bool operator<(partial_ordering v, cmp::unspec) noexcept {
+		return v.is_ordered() && v.value < 0;
+	}
+
+	friend constexpr bool operator>(partial_ordering v, cmp::unspec) noexcept {
+		return v.is_ordered() && v.value > 0;
+	}
+
+	friend constexpr bool operator<=(partial_ordering v, cmp::unspec) noexcept {
+		return v.is_ordered() && v.value <= 0;
+	}
+
+	friend constexpr bool operator>=(partial_ordering v, cmp::unspec) noexcept {
+		return v.is_ordered() && v.value >= 0;
+	}
+
+	friend constexpr bool operator<(cmp::unspec, partial_ordering v) noexcept {
+		return v.is_ordered() && 0 < v.value;
+	}
+
+	friend constexpr bool operator>(cmp::unspec, partial_ordering v) noexcept {
+		return v.is_ordered() && 0 > v.value;
+	}
+
+	friend constexpr bool operator<=(cmp::unspec, partial_ordering v) noexcept {
+		return v.is_ordered() && 0 <= v.value;
+	}
+
+	friend constexpr bool operator>=(cmp::unspec, partial_ordering v) noexcept {
+		return v.is_ordered() && 0 >= v.value;
+	}
+
+	friend constexpr partial_ordering operator<=>(partial_ordering v, cmp::unspec) noexcept {
+		return v;
+	}
+
+	friend constexpr partial_ordering operator<=>(cmp::unspec, partial_ordering v) noexcept {
+		return v < 0 ? partial_ordering::greater : (v > 0 ? partial_ordering::less : v);
+	}
+};
+
+inline constexpr partial_ordering partial_ordering::less(cmp::order::less);
+inline constexpr partial_ordering partial_ordering::equivalent(cmp::order::equivalent);
+inline constexpr partial_ordering partial_ordering::greater(cmp::order::greater);
+inline constexpr partial_ordering partial_ordering::unordered(cmp::ncmp::unordered);
+
+class weak_ordering {
+	cmp::value_type value;
+
+	constexpr explicit weak_ordering(cmp::order v) noexcept : value(cmp::value_type(v)) { }
+
+	public:
+	static const weak_ordering less;
+	static const weak_ordering equivalent;
+	static const weak_ordering greater;
+
+	constexpr operator partial_ordering() const noexcept {
+		return value == 0 ? partial_ordering::equivalent : (value < 0 ? partial_ordering::less : partial_ordering::greater);
+	}
+
+	friend constexpr bool operator==(weak_ordering v, weak_ordering w) noexcept = default;
+
+	friend constexpr bool operator==(weak_ordering v, cmp::unspec) noexcept {
+		return v.value == 0;
+	}
+
+	friend constexpr bool operator<(weak_ordering v, cmp::unspec) noexcept {
+		return v.value < 0;
+	}
+
+	friend constexpr bool operator>(weak_ordering v, cmp::unspec) noexcept {
+		return v.value > 0;
+	}
+
+	friend constexpr bool operator<=(weak_ordering v, cmp::unspec) noexcept {
+		return v.value <= 0;
+	}
+
+	friend constexpr bool operator>=(weak_ordering v, cmp::unspec) noexcept {
+		return v.value >= 0;
+	}
+
+	friend constexpr bool operator<(cmp::unspec, weak_ordering v) noexcept {
+		return 0 < v.value;
+	}
+
+	friend constexpr bool operator>(cmp::unspec, weak_ordering v) noexcept {
+		return 0 > v.value;
+	}
+
+	friend constexpr bool operator<=(cmp::unspec, weak_ordering v) noexcept {
+		return 0 <= v.value;
+	}
+
+	friend constexpr bool operator>=(cmp::unspec, weak_ordering v) noexcept  {
+		return 0 >= v.value;
+	}
+
+	friend constexpr weak_ordering operator<=>(weak_ordering v, cmp::unspec) noexcept {
+		return v;
+	}
+
+	friend constexpr weak_ordering operator<=>(cmp::unspec, weak_ordering v) noexcept {
+		return v < 0 ? weak_ordering::greater : (v > 0 ? weak_ordering::less : v);
+	}
+};
+
+inline constexpr weak_ordering weak_ordering::less(cmp::order::less);
+inline constexpr weak_ordering weak_ordering::equivalent(cmp::order::equivalent);
+inline constexpr weak_ordering weak_ordering::greater(cmp::order::greater);
+
+class strong_ordering {
+	cmp::value_type value;
+
+	constexpr explicit strong_ordering(cmp::order v) noexcept : value(cmp::value_type(v)) { }
+
+	public:
+	static const strong_ordering less;
+	static const strong_ordering equal;
+	static const strong_ordering equivalent;
+	static const strong_ordering greater;
+
+	constexpr operator partial_ordering() const noexcept {
+		return value == 0 ? partial_ordering::equivalent : (value < 0 ? partial_ordering::less : partial_ordering::greater);
+	}
+
+	constexpr operator weak_ordering() const noexcept {
+		return value == 0 ? weak_ordering::equivalent : (value < 0 ? weak_ordering::less : weak_ordering::greater);
+	}
+
+	friend constexpr bool operator==(strong_ordering v, strong_ordering w) noexcept = default;
+
+	friend constexpr bool operator==(strong_ordering v, cmp::unspec) noexcept {
+		return v.value == 0;
+	}
+
+	friend constexpr bool operator<(strong_ordering v, cmp::unspec) noexcept {
+		return v.value < 0;
+	}
+
+	friend constexpr bool operator>(strong_ordering v, cmp::unspec) noexcept {
+		return v.value > 0;
+	}
+
+	friend constexpr bool operator<=(strong_ordering v, cmp::unspec) noexcept {
+		return v.value <= 0;
+	}
+
+	friend constexpr bool operator>=(strong_ordering v, cmp::unspec) noexcept {
+		return v.value >= 0;
+	}
+
+	friend constexpr bool operator<(cmp::unspec, strong_ordering v) noexcept {
+		return 0 < v.value;
+	}
+
+	friend constexpr bool operator>(cmp::unspec, strong_ordering v) noexcept {
+		return 0 > v.value;
+	}
+
+	friend constexpr bool operator<=(cmp::unspec, strong_ordering v) noexcept {
+		return 0 <= v.value;
+	}
+
+	friend constexpr bool operator>=(cmp::unspec, strong_ordering v) noexcept {
+		return 0 >= v.value;
+	}
+
+	friend constexpr strong_ordering operator<=>(strong_ordering v, cmp::unspec) noexcept {
+		return v;
+	}
+
+	friend constexpr strong_ordering operator<=>(cmp::unspec, strong_ordering v) noexcept {
+		return v < 0 ? strong_ordering::greater : (v > 0 ? strong_ordering::less : v);
+	}
+};
+
+inline constexpr strong_ordering strong_ordering::less(cmp::order::less);
+inline constexpr strong_ordering strong_ordering::equal(cmp::order::equivalent);
+inline constexpr strong_ordering strong_ordering::equivalent(cmp::order::equivalent);
+inline constexpr strong_ordering strong_ordering::greater(cmp::order::greater);
+
+namespace detail {
+
+template<unsigned int>
+struct common_cmpcat_base { using type = void; };
+template<>
+struct common_cmpcat_base<0u> { using type = strong_ordering; };
+template<>
+struct common_cmpcat_base<2u> { using type = partial_ordering; };
+template<>
+struct common_cmpcat_base<4u> { using type = weak_ordering; };
+template<>
+struct common_cmpcat_base<6u> { using type = partial_ordering; };
+
+} // namespace detail
+
+template<class...Ts>
+struct common_comparison_category :
+	detail::common_cmpcat_base<(0u | ... |
+		(is_same_v<Ts, strong_ordering>  ? 0u :
+		 is_same_v<Ts, weak_ordering>    ? 4u :
+		 is_same_v<Ts, partial_ordering> ? 2u : 1u)
+	)> {};
+
+template<class... Ts>
+using common_comparison_category_t = typename common_comparison_category<Ts...>::type;
+
+template<class T, class U = T>
+using compare_three_way_result_t = decltype(
+	declval<const remove_reference_t<T>&>() <=>
+	declval<const remove_reference_t<U>&>()
+);
+
+template<class T, class U = T>
+struct compare_three_way_result { };
+
+template<class T, class U> requires requires { typename compare_three_way_result_t<T, U>; }
+struct compare_three_way_result<T, U> {
+	using type = compare_three_way_result_t<T, U>;
+};
+
+struct compare_three_way {
+	template<class T, class U>
+	constexpr auto operator()(T&& t, U&& u) const noexcept(noexcept(forward<T>(t) <=> forward<U>(u))) {
+		return forward<T>(t) <=> forward<U>(u);
+	}
+
+	using is_transparent = void;
+};
+
+// TODO: strong_order, weak_order, partial_order
+// TODO: compare_strong_order_fallback, compare_weak_order_fallback, compare_partial_order_fallback
+
+constexpr bool is_eq(partial_ordering cmp) noexcept { return cmp == 0; }
+constexpr bool is_neq(partial_ordering cmp) noexcept { return cmp != 0; }
+constexpr bool is_lt(partial_ordering cmp) noexcept { return cmp < 0; }
+constexpr bool is_lteq(partial_ordering cmp) noexcept { return cmp <= 0; }
+constexpr bool is_gt(partial_ordering cmp) noexcept { return cmp > 0; }
+constexpr bool is_gteq(partial_ordering cmp) noexcept { return cmp >= 0; }
+
+} // namespace std
+
+#endif // !defined(CXXSHIM_INTEGRATE_GCC)
+
+#endif // _CXXSHIM_COMPARE

--- a/stage2/include/cstdarg
+++ b/stage2/include/cstdarg
@@ -1,0 +1,13 @@
+#ifndef _CXXSHIM_CSTDARG
+#define _CXXSHIM_CSTDARG
+
+#include <stdarg.h>
+
+namespace std
+{
+
+using ::va_list;
+
+} // namespace std
+
+#endif // _CXXSHIM_CSTDARG

--- a/stage2/include/cstddef
+++ b/stage2/include/cstddef
@@ -8,7 +8,8 @@ namespace std {
 enum class [[gnu::may_alias]] byte : unsigned char { };
 
 using nullptr_t = decltype(nullptr);
-using size_t = ::size_t;
+using ::ptrdiff_t;
+using ::size_t;
 
 } // namespace std
 

--- a/stage2/include/new
+++ b/stage2/include/new
@@ -15,6 +15,11 @@ inline void *operator new (size_t, void *p) {
 
 namespace std {
 
+enum class align_val_t : size_t { };
+
+struct destroying_delete_t { explicit destroying_delete_t() = default; };
+inline constexpr destroying_delete_t destroying_delete { };
+
 template<typename T>
 [[nodiscard]] constexpr T *launder(T *p) noexcept {
 	return __builtin_launder(p);

--- a/stage2/include/utility
+++ b/stage2/include/utility
@@ -63,6 +63,25 @@ using make_index_sequence = make_integer_sequence<size_t, N>;
 template<typename... T>
 using index_sequence_for = make_index_sequence<sizeof...(T)>;
 
+struct piecewise_construct_t { explicit piecewise_construct_t() = default; };
+inline constexpr piecewise_construct_t piecewise_construct { };
+
+struct in_place_t { explicit in_place_t() = default; };
+
+inline constexpr in_place_t in_place { };
+
+template<typename T>
+struct in_place_type_t { explicit in_place_type_t() = default; };
+
+template<typename T>
+inline constexpr in_place_type_t<T> in_place_type { };
+
+template<size_t I>
+struct in_place_index_t { explicit in_place_index_t() = default; };
+
+template<size_t I>
+inline constexpr in_place_index_t<I> in_place_index { };
+
 struct source_location {
 	static consteval source_location current(
 			const char *file = __builtin_FILE(),


### PR DESCRIPTION
added headers: cfloat, cinttypes, climits, cstdarg, compare

* compare
  - partial_ordering
  - weak_ordering
  - strong_ordering
  - common_comparison_category/_t
  - compare_three_way_result/_t
  - compare_three_way
  - is_eq
  - is_neq
  - is_lt
  - is_lteq
  - is_gt
  - is_gteq

* cstddef
  - std::ptrdiff_t

* cinttypes
  - std::imaxdiv_t

<!---
* memory
  - std::allocator
-->
* new
  - align_val_t
  - destroying_delete/_t

* algorithm
  - constexpr min/max

* utility
  - piecewise_construct/_t
  - in_place/_t
  - in_place_type/_t
  - in_place_index/_t